### PR TITLE
Add MQTT Auto discovery (device) support for HomeAssistant

### DIFF
--- a/InverterData.py
+++ b/InverterData.py
@@ -17,7 +17,6 @@ import configparser
 import datetime
 from influxdb import InfluxDBClient
 from datetime import datetime
-from time import sleep
 
 def twosComplement_hex(hexval, reg):
     if hexval=="":

--- a/InverterHWData.py
+++ b/InverterHWData.py
@@ -18,7 +18,7 @@ def hex_zfill(intval):
     hexvalue=hex(intval)
     return '0x' + str(hexvalue)[2:].zfill(4)
 
-os.chdir(os.path.dirname(sys.argv[0]))
+os.chdir(os.path.dirname(os.path.abspath(sys.argv[0])))
 
 # CONFIG
 configParser = configparser.RawConfigParser()

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ mqtt_cacert=                    # CA certificate path/filename
 [Domoticz]
 domoticz_support=0              # 0: disabled, 1: enabled
 
+[HomeAssistant]
+homeassistant_support=0         # 0: disabled, 1: enabled
+
 Files SOFARMap.xml and SOFARHWMap.xml contain MODBUS inverter's registers mapping for Sofar Solar K-TLX product line
 and Prometheus/InfluxDB metrics configuration.
 Edit i.e. to get captions in a different language, change Prometheus/InfluxDB metrics names or

--- a/config.cfg
+++ b/config.cfg
@@ -1,15 +1,15 @@
 [SofarInverter]
-inverter_ip=
+inverter_ip=10.0.0.55
 inverter_port=8899
-inverter_sn=
+inverter_sn=1718230944
 register_start1=0x0000
 register_end1=0x0027
 register_start2=0x0105
 register_end2=0x0114
 registerhw_start=0x2000
 registerhw_end=0x200D
-lang=EN
-verbose=0
+lang=PL
+verbose=1
 
 [Prometheus]
 prometheus=0
@@ -24,16 +24,19 @@ influxdb_password=
 influxdb_dbname=
 
 [MQTT]
-mqtt=0
-mqtt_server=
+mqtt=1
+mqtt_server=10.0.0.111
 mqtt_port=1883
-mqtt_topic=
-mqtt_username=
-mqtt_passwd=
+mqtt_topic=sofar
+mqtt_username=home
+mqtt_passwd=pablosss123
 mqtt_tls=0
 mqtt_tls_insecure=True
 mqtt_tls_version=2
 mqtt_cacert=
 
 [Domoticz]
-domoticz_support=0
+domoticz_support=1
+
+[HomeAssistant]
+homeassistant_support=1

--- a/config.cfg
+++ b/config.cfg
@@ -1,15 +1,15 @@
 [SofarInverter]
-inverter_ip=10.0.0.55
+inverter_ip=
 inverter_port=8899
-inverter_sn=1718230944
+inverter_sn=
 register_start1=0x0000
 register_end1=0x0027
 register_start2=0x0105
 register_end2=0x0114
 registerhw_start=0x2000
 registerhw_end=0x200D
-lang=PL
-verbose=1
+lang=EN
+verbose=0
 
 [Prometheus]
 prometheus=0
@@ -24,19 +24,19 @@ influxdb_password=
 influxdb_dbname=
 
 [MQTT]
-mqtt=1
-mqtt_server=10.0.0.111
+mqtt=0
+mqtt_server=
 mqtt_port=1883
-mqtt_topic=sofar
-mqtt_username=home
-mqtt_passwd=pablosss123
+mqtt_topic=
+mqtt_username=
+mqtt_passwd=
 mqtt_tls=0
 mqtt_tls_insecure=True
 mqtt_tls_version=2
 mqtt_cacert=
 
 [Domoticz]
-domoticz_support=1
+domoticz_support=0
 
 [HomeAssistant]
 homeassistant_support=1


### PR DESCRIPTION
The functionality allows the device (logger) to be automatically detected in HomeAssistant in MQTT integration.
Data from daily or total production can be used in the ENERGY tab
![ha_0](https://user-images.githubusercontent.com/57967133/155280708-a1abb497-1598-4564-a505-72669779375d.jpg)
![ha_1](https://user-images.githubusercontent.com/57967133/155280717-a0c6f907-7a3f-4622-a5d4-ac640a72cc7e.jpg)
![ha_2](https://user-images.githubusercontent.com/57967133/155280733-0357cd0e-4539-4c04-83d7-1bdfb6e11e85.jpg)
![ha_3](https://user-images.githubusercontent.com/57967133/155280750-25461cea-77e0-48c1-b300-2fda0ba2416c.jpg)

